### PR TITLE
Bind mount node_modules to avoid win path length

### DIFF
--- a/salt/roots/symmounts.sls
+++ b/salt/roots/symmounts.sls
@@ -4,9 +4,7 @@
     - group: vagrant
 
 /vagrant/node_modules:
-  file.directory:
-    - user: vagrant
-    - group: vagrant
+  file.directory
 
 symmount:
   mount.mounted:

--- a/salt/roots/symmounts.sls
+++ b/salt/roots/symmounts.sls
@@ -1,0 +1,21 @@
+/tmp/node_modules:
+  file.directory:
+    - user: vagrant
+    - group: vagrant
+
+/vagrant/node_modules:
+  file.directory:
+    - user: vagrant
+    - group: vagrant
+
+symmount:
+  mount.mounted:
+    - name: /vagrant/node_modules
+    - device: /tmp/node_modules
+    - fstype: None
+    - opts:
+      - bind
+    - user: vagrant
+    - require:
+       - file: /tmp/node_modules
+       - file: /vagrant/node_modules

--- a/salt/roots/top.sls
+++ b/salt/roots/top.sls
@@ -1,5 +1,6 @@
 base:
   '*':
+    - symmounts
     - git
     - node
     - npmdeps


### PR DESCRIPTION
Using salt provisioner have the VM do a bind mount (skirts VirtualBox's
limits with creating symlinks) so that node_modules is actually a
directory inside the VM. This also makes 'npm install' a *lot* faster.