### PR TITLE
#8 - added client unit test structure and some tests

### DIFF
--- a/app/client/Gulpfile.js
+++ b/app/client/Gulpfile.js
@@ -1,1 +1,2 @@
+require('babel/register');
 require('./gulp');

--- a/app/client/gulp/config.js
+++ b/app/client/gulp/config.js
@@ -10,6 +10,7 @@ global.config = {
       assets: [SRC_FOLDER + '/assets/**/*', '!' + SRC_FOLDER + '/assets/images/**/*'],
       images: SRC_FOLDER + '/assets/images/**/*',
       scripts: SRC_FOLDER + '/modules/**/*.js',
+      test: SRC_FOLDER + '/modules/**/*.test.js',
       styles: [SRC_FOLDER + '/styles/app.scss'],
       bowerStyles: ['bower_components/angular-material/angular-material.css'],
       stylesGlob: SRC_FOLDER + '/styles/**/*.scss',

--- a/app/client/gulp/tasks/default.js
+++ b/app/client/gulp/tasks/default.js
@@ -7,14 +7,14 @@ module.exports = gulp.task('default', function () {
   if (release) {
     runSequence(
       'clean',
-      ['index', 'styles', 'images', 'assets', 'templates', 'lint'],
+      ['index', 'styles', 'images', 'assets', 'templates', 'lint', 'test'],
       'browserify',
       ['minify']
     );
   } else {
     runSequence(
       'clean',
-      ['index', 'styles', 'images', 'assets', 'templates', 'lint'],
+      ['index', 'styles', 'images', 'assets', 'templates', 'lint', 'test'],
       ['watchify', 'watch']
     );
   }

--- a/app/client/gulp/tasks/test.js
+++ b/app/client/gulp/tasks/test.js
@@ -23,7 +23,7 @@ module.exports = gulp.task('test', () => {
                 gulp.src(config.paths.src.test)
                     .pipe(mocha())
                     .pipe(istanbul.writeReports({
-                        reporters: ['lcov', 'text-summary']
+                        reporters: ['lcov', 'text', 'text-summary']
                     }))
                     .on('end', resolve);
             });

--- a/app/client/gulp/tasks/test.js
+++ b/app/client/gulp/tasks/test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var gulp = require('gulp'),
+    istanbul = require('gulp-istanbul'),
+    isparta = require('isparta'),
+    Bluebird = require('bluebird'),
+    mocha = require('gulp-mocha');
+
+//instrument all src
+function instrumentSource() {
+    return gulp.src(config.paths.src.scripts)
+        .pipe(istanbul({
+            instrumenter: isparta.Instrumenter,
+            includeUntested: true
+        }))
+        .pipe(istanbul.hookRequire());
+}
+
+module.exports = gulp.task('test', () => {
+    return new Bluebird((resolve) => {
+        instrumentSource()
+            .on('finish', () => {
+                gulp.src(config.paths.src.test)
+                    .pipe(mocha())
+                    .pipe(istanbul.writeReports({
+                        reporters: ['lcov', 'text-summary']
+                    }))
+                    .on('end', resolve);
+            });
+    });
+});

--- a/app/client/src/modules/common/directives/repodetails/repodetails.js
+++ b/app/client/src/modules/common/directives/repodetails/repodetails.js
@@ -17,7 +17,7 @@ module.exports = /*@ngInject*/
                 function (linkService) {
                     console.log('binding repo details controller', this);
 
-                    this.editLink = links.findByRel('edit-user-permission', this.repo.links);
+                    this.editLink = links.findByRel(this.repo.links, 'edit-user-permission');
                     this.buttons = angular.copy(buttonConfig);
 
                     let perm = this.repo.permission;

--- a/app/client/src/modules/common/directives/userdetails/userdetails.js
+++ b/app/client/src/modules/common/directives/userdetails/userdetails.js
@@ -16,7 +16,7 @@ module.exports = /*@ngInject*/
             controller: /*@ngInject*/
                 function (linkService) {
                     console.log('binding user details controller', this);
-                    this.editLink = links.findByRel('edit-repo-permission', this.user.links);
+                    this.editLink = links.findByRel(this.user.links, 'edit-repo-permission');
                     this.buttons = angular.copy(buttonConfig);
 
                     let perm = this.user.permission;

--- a/app/client/src/modules/hash.test.js
+++ b/app/client/src/modules/hash.test.js
@@ -1,0 +1,29 @@
+'use strict';
+let chai = require('chai'),
+    hash = require('./hash');
+
+describe('hash.js', () => {
+
+    let items = [{
+        id: 'item1',
+        value: 1
+    }, {
+        id: 'item2',
+        value: 2
+    }, {
+        id: 'item3',
+        value: 3
+    }];
+
+    it('creates hash from array', () => {
+
+        let hashed = hash(items, 'id');
+
+        chai.assert.equal(1, hashed.item1.value);
+        chai.assert.equal(2, hashed.item2.value);
+        chai.assert.equal(3, hashed.item3.value);
+
+        chai.assert.isUndefined(hashed.item4);
+
+    });
+});

--- a/app/client/src/modules/links.js
+++ b/app/client/src/modules/links.js
@@ -9,10 +9,10 @@ module.exports = {
 
     /**
      * Finds a link that matches a specified rel.
-     * @param rel
      * @param links
+     * @param rel
      */
-    findByRel (rel, links) {
+    findByRel (links, rel) {
         //TODO: es6 polyfill for 'find'
         let link;
         if (links) {

--- a/app/client/src/modules/links.test.js
+++ b/app/client/src/modules/links.test.js
@@ -1,0 +1,43 @@
+'use strict';
+let chai = require('chai'),
+    links = require('./links');
+
+describe('links.js', () => {
+
+    let items = [{
+        href: '/api/items/1',
+        rel: 'edit',
+        method: 'PUT'
+    }, {
+        href: '/api/items/1',
+        rel: 'self',
+        method: 'GET'
+    }, {
+        href: '/api/items/1',
+        rel: 'remove',
+        method: 'DELETE'
+    }];
+
+    describe('findByRel', () => {
+
+        it('finds link by rel', () => {
+
+            let link = links.findByRel(items, 'edit');
+
+            chai.assert.equal('/api/items/1', link.href);
+            chai.assert.equal('edit', link.rel);
+            chai.assert.equal('PUT', link.method);
+
+        });
+
+        it('returns undefined with non-existent rel', () => {
+
+            let link = links.findByRel(items, 'collection');
+
+            chai.assert.isUndefined(link);
+
+        });
+
+    });
+
+});

--- a/app/client/src/modules/permissions.test.js
+++ b/app/client/src/modules/permissions.test.js
@@ -1,0 +1,53 @@
+'use strict';
+let chai = require('chai'),
+    permissions = require('./permissions');
+
+describe('permission.js', () => {
+
+    describe('highest', () => {
+
+        it('finds highest permission in an ordered list', () => {
+            let highest = permissions.highest(['pull', 'push']);
+            chai.assert.equal('push', highest);
+        });
+
+        it('finds highest permission in an unordered list', () => {
+            let highest = permissions.highest(['admin', 'pull', 'push']);
+            chai.assert.equal('admin', highest);
+        });
+
+    });
+
+    describe('greaterThan', () => {
+
+        it('[pull] is higher than [none]', () => {
+            chai.assert.isTrue(permissions.greaterThan('pull', 'none'));
+        });
+
+        it('[push] is higher than [none]', () => {
+            chai.assert.isTrue(permissions.greaterThan('push', 'none'));
+        });
+
+        it('[push] is higher than [pull]', () => {
+            chai.assert.isTrue(permissions.greaterThan('push', 'pull'));
+        });
+
+        it('[admin] is higher than [push]', () => {
+            chai.assert.isTrue(permissions.greaterThan('admin', 'push'));
+        });
+
+    });
+
+    describe('friendly', () => {
+
+        it('pull === read', () => {
+            chai.assert.equal('read', permissions.friendly('pull'));
+        });
+
+        it('push === write', () => {
+            chai.assert.equal('write', permissions.friendly('push'));
+        });
+
+    });
+
+});

--- a/gulp.tasks.js
+++ b/gulp.tasks.js
@@ -60,7 +60,7 @@ gulp.task('test', () => {
                 gulp.src(SERVER_TEST_SRC)
                     .pipe(mocha())
                     .pipe(istanbul.writeReports({
-                        reporters: ['lcov', 'text-summary']
+                        reporters: ['lcov', 'text', 'text-summary']
                     }))
                     .on('end', resolve);
             });
@@ -73,7 +73,9 @@ gulp.task('itest', () => {
             .on('finish', () => {
                 gulp.src(SERVER_IT_SRC)
                     .pipe(mocha())
-                    .pipe(istanbul.writeReports())
+                    .pipe(istanbul.writeReports({
+                        reporters: ['lcov', 'text', 'text-summary']
+                    }))
                     .on('end', resolve);
             });
     });

--- a/gulp.tasks.js
+++ b/gulp.tasks.js
@@ -52,6 +52,7 @@ function instrumentSource() {
         }))
         .pipe(istanbul.hookRequire());
 }
+
 gulp.task('test', () => {
     return new Bluebird((resolve, reject) => {
         instrumentSource()

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "gulp-watch": "^0.6.9",
     "isparta": "^2.2.0",
     "jshint-stylish": "^0.2.0",
+    "lodash": "3.5.0",
     "mocha": "^2.1.0",
     "request": "2.53.0",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
Note that gulp is now running as es6 since the unit tests load client code. This means the watcher exhibits [this error](https://github.com/wearefractal/glob-watcher/issues/15). It requires restart of the watcher, unless you choose to hand-edit node_modules as per [this thread](https://github.com/babel/babel/issues/489#issuecomment-69919417).

<!---
@huboard:{"order":6.125,"milestone_order":124,"custom_state":""}
-->
