### PR TITLE
#123 - made buttons disabled instead of hidden

### DIFF
--- a/app/client/src/modules/common/directives/repodetails/repodetails.html
+++ b/app/client/src/modules/common/directives/repodetails/repodetails.html
@@ -8,7 +8,7 @@
             <div ng-if="ctrl.repo.description" class="repo-details-description">{{ctrl.repo.description}}</div>
         </div>
         <div class="repo-links">
-            <div ng-if="ctrl.editLink" class="repo-details-edit-permissions">
+            <div ng-if="ctrl.permission" class="repo-details-edit-permissions">
                 <span togglebuttons
                       options="ctrl.buttons"
                       value="ctrl.permission"

--- a/app/client/src/modules/common/directives/repodetails/repodetails.js
+++ b/app/client/src/modules/common/directives/repodetails/repodetails.js
@@ -20,6 +20,11 @@ module.exports = /*@ngInject*/
                     this.editLink = links.findByRel(this.repo.links, 'edit-user-permission');
                     this.buttons = angular.copy(buttonConfig);
 
+                    //buttons display but are not clickable if the link isn't there
+                    if (!this.editLink) {
+                        this.buttons.forEach((btn) => btn.disabled = true);
+                    }
+
                     let perm = this.repo.permission;
 
                     if (perm) {

--- a/app/client/src/modules/common/directives/togglebuttons.html
+++ b/app/client/src/modules/common/directives/togglebuttons.html
@@ -1,6 +1,6 @@
 <span ng-repeat="o in ctrl.options">
     <md-button
-            ng-class="{'md-primary': ctrl.value == o.value}"
+            ng-class="{'md-primary permission-current': ctrl.value == o.value}"
             ng-disabled="o.disabled"
             ng-click="ctrl.click(o.value)">
         {{o.label}}

--- a/app/client/src/modules/common/directives/userdetails/userdetails.html
+++ b/app/client/src/modules/common/directives/userdetails/userdetails.html
@@ -8,7 +8,7 @@
             <div ng-if="ctrl.user.username" class="user-details-username">{{ctrl.user.username}}</div>
         </div>
         <div class="user-links">
-            <div ng-if="ctrl.editLink" class="user-details-edit-permissions">
+            <div ng-if="ctrl.permission" class="user-details-edit-permissions">
                 <span togglebuttons
                      options="ctrl.buttons"
                      value="ctrl.permission"

--- a/app/client/src/modules/common/directives/userdetails/userdetails.js
+++ b/app/client/src/modules/common/directives/userdetails/userdetails.js
@@ -19,6 +19,11 @@ module.exports = /*@ngInject*/
                     this.editLink = links.findByRel(this.user.links, 'edit-repo-permission');
                     this.buttons = angular.copy(buttonConfig);
 
+                    //buttons display but are not clickable if the link isn't there
+                    if (!this.editLink) {
+                        this.buttons.forEach((btn) => btn.disabled = true);
+                    }
+
                     let perm = this.user.permission;
 
                     if (perm) {

--- a/app/client/src/styles/app.scss
+++ b/app/client/src/styles/app.scss
@@ -16,6 +16,7 @@ body, html {
 .github-permission {
     text-transform: uppercase;
     font-size: 11px;
+    margin-top: 6px;
     margin-right: 6px;
     text-align: right;
     padding-right: 18px;
@@ -26,4 +27,9 @@ body, html {
     color: #000;
     opacity: .25;
     display: block;
+}
+
+.permission-current {
+    border: 1px solid #ccc;
+    border-radius: 4px;
 }


### PR DESCRIPTION
To do this, I had to make a couple of changes:

1. The toggle button visibility is now based on the permission field
presence, because basing it on the editLink makes them hide if the
logged in user does not have admin
2. Added a border style to the current permission button, so that it is
still obvious when disabled (which removes the color)